### PR TITLE
Better error handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,6 @@ Imports:
     broom,
     glue,
     MASS
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/man/brkpt.Rd
+++ b/man/brkpt.Rd
@@ -5,14 +5,12 @@
 \alias{brkpt.nb}
 \title{Fit breakpoint model to individual colony}
 \usage{
-brkpt(data, taus = NULL, t, formula, family = gaussian(link = "log"), ...)
+brkpt(data, t, formula, family = gaussian(link = "log"), taus = NULL, ...)
 
 brkpt.nb(data, taus = NULL, t, formula, link = "log", ...)
 }
 \arguments{
 \item{data}{a dataframe or tibble}
-
-\item{taus}{an optional vector of taus to test. If not supplied, \code{seq(min(t), max(t), length.out = 50)} will be used}
 
 \item{t}{the unquoted column name for the time variable in \code{data}}
 
@@ -20,6 +18,8 @@ brkpt.nb(data, taus = NULL, t, formula, link = "log", ...)
 include the time variable supplied to \code{t}}
 
 \item{family}{passed to \code{glm()}}
+
+\item{taus}{an optional vector of taus to test. If not supplied, \code{seq(min(t), max(t), length.out = 50)} will be used}
 
 \item{...}{additional arguments passed to \code{glm()} or \code{glm.nb()}}
 

--- a/man/bumbl.Rd
+++ b/man/bumbl.Rd
@@ -7,10 +7,10 @@
 \usage{
 bumbl(
   data,
-  colonyID = NULL,
   t,
   formula,
   family = gaussian(link = "log"),
+  colonyID = NULL,
   augment = FALSE,
   taus = NULL,
   ...
@@ -30,8 +30,6 @@ bumbl.nb(
 \arguments{
 \item{data}{a dataframe or tibble}
 
-\item{colonyID}{the unquoted column name of the colony ID variable}
-
 \item{t}{the unquoted column name of the time variable in (units???)}
 
 \item{formula}{a formula with the form \code{response ~ time + covariates} where
@@ -40,6 +38,8 @@ you have (date, number of weeks, etc.) and covariates are any optional
 co-variates you want to fit at the colony level.}
 
 \item{family}{passed to \code{glm()}.}
+
+\item{colonyID}{the unquoted column name of the colony ID variable}
 
 \item{augment}{when FALSE, \code{bumbl} returns a summary dataframe with one row
 for each colonyID.  When TRUE, it returns the original data with additional

--- a/tests/testthat/test-bumbl.R
+++ b/tests/testthat/test-bumbl.R
@@ -102,3 +102,8 @@ test_that("bumbl works when no Colony ID supplied", {
     "data.frame"
   )
 })
+
+test_that("error handling", {
+  expect_error(brkpt(bombus_67, t = week, formula = I(d.mass-1) ~ week), regexp = "No valid values for tau found.+")
+  expect_error(bumbl(bombus_sub, t = week, formula = I(d.mass - 1) ~ week), "Model fitting failed for all colonies.")
+})


### PR DESCRIPTION
`bumbl()` now errors earlier and more informatively if the model fitting fails for all colonies.
`brkpt()` no longer errors if the first iteration of tau causes the glm to fail.  It only errors if there are multiple equivalent taus or if zero valid taus were found. Closes #30 and #31 